### PR TITLE
Update mqtt-client Alpine to version 3.9

### DIFF
--- a/mqtt-client/Dockerfile
+++ b/mqtt-client/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.9
 MAINTAINER Emmanuel Frecon <efrecon@gmail.com>
 
 VOLUME /opt/certs
@@ -7,3 +7,5 @@ RUN apk add --no-cache mosquitto-clients ca-certificates && \
     /etc/ca-certificates/update.d/certhash && \
     ln -s /usr/bin/mosquitto_pub /usr/local/bin/pub && \
     ln -s /usr/bin/mosquitto_sub /usr/local/bin/sub
+
+USER nobody


### PR DESCRIPTION
- Allows for the use of -F/format flag introduced in Mosquitto 1.5. Very helpful for watching protobuf or other binary formats over MQTT.
- Switch to nobody user, `mosquitto_*` do not require elevated permissions.
