### PR TITLE
chafa

### DIFF
--- a/.github/workflows/chafa.yml
+++ b/.github/workflows/chafa.yml
@@ -1,0 +1,71 @@
+name: chafa
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'master'
+      - 'feature/chafa'
+    paths:
+      - 'chafa/**'
+      - '.github/workflows/chafa.yml'
+  schedule:
+      - cron: "0 0 * * *"
+
+jobs:
+  chafa:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      -
+        name: Login to GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Build GHCR images
+        env:
+          DOCKER_REPO: ghcr.io/efrecon/chafa
+          SOURCE_COMMIT: ${{ github.sha }}
+        run: cd chafa && ./hooks/build
+      -
+        name: Push GHCR images
+        env:
+          DOCKER_REPO: ghcr.io/efrecon/chafa
+          SOURCE_COMMIT: ${{ github.sha }}
+        run: cd chafa && ./hooks/push
+      -
+        name: Login to Docker Hub Registry
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build Docker Hub images
+        env:
+          DOCKER_REPO: docker.io/efrecon/chafa
+          SOURCE_COMMIT: ${{ github.sha }}
+        run: cd chafa && ./hooks/build
+      -
+        name: Push Docker Hub images
+        env:
+          DOCKER_REPO: docker.io/efrecon/chafa
+          SOURCE_COMMIT: ${{ github.sha }}
+        run: cd chafa && ./hooks/push
+      -
+        # Note: This uses the password, not the token as this action would
+        # otherwise not work.
+        name: Update repo description at Docker Hub
+        uses: peter-evans/dockerhub-description@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          repository: efrecon/chafa
+          short-description: Terminal graphics for the 21st century.
+          readme-filepath: ./chafa/README.md

--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "binenv/hooks/reg-tags"]
 	path = binenv/hooks/reg-tags
 	url = https://github.com/efrecon/reg-tags.git
+[submodule "chafa/hooks/reg-tags"]
+	path = chafa/hooks/reg-tags
+	url = https://github.com/efrecon/reg-tags.git

--- a/chafa/Dockerfile
+++ b/chafa/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get -y update \
 COPY --from=build /usr/local /usr/local
 ENV LD_LIBRARY_PATH=/usr/local/lib
 RUN ldconfig
+RUN chafa --version
 
 ENTRYPOINT [ "chafa" ]
 CMD [ "--help" ]

--- a/chafa/Dockerfile
+++ b/chafa/Dockerfile
@@ -1,6 +1,8 @@
 ARG UBUNTU_VERSION=20.04
 ARG CHAFA_VERSION=1.8.0
 
+# First stage: fetch the official released source code, compile it and install
+# it into /usr/local
 FROM ubuntu:${UBUNTU_VERSION} AS build
 
 ARG GHPROJ=hpjansson/chafa
@@ -11,12 +13,16 @@ RUN apt-get -y update \
   && curl -sSL "https://github.com/${GHPROJ}/releases/download/${CHAFA_VERSION}/chafa-${CHAFA_VERSION}.tar.xz" > /tmp/chafa-${CHAFA_VERSION}.tar.xz \
   && xzcat /tmp/chafa-${CHAFA_VERSION}.tar.xz | tar -C /tmp -xvf - \
   && cd /tmp/chafa-${CHAFA_VERSION} \
-  && mkdir /tmp/usr && mkdir build && cd build && ../autogen.sh --prefix=/usr/local --disable-dependency-tracking && make -j4 && make install
-#  && rm -rf /tmp/chafa-${CHAFA_VERSION}*
+  && mkdir build \
+  && cd build \
+  && ../autogen.sh --prefix=/usr/local --disable-dependency-tracking \
+  && make -j4 \
+  && make install
 
+
+# Second stage: install non-dev dependencies, copy the installation binaries and
+# libraries from previous stage and fix OS dynlib cache.
 FROM ubuntu:${UBUNTU_VERSION}
-
-ARG CHAFA_VERSION
 
 RUN apt-get -y update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq libglib2.0 libmagickwand-6.q16

--- a/chafa/Dockerfile
+++ b/chafa/Dockerfile
@@ -1,0 +1,28 @@
+ARG CHAFA_VERSION=1.8.0
+
+FROM ubuntu:20.04 AS build
+
+ARG GHPROJ=hpjansson/chafa
+ARG CHAFA_VERSION
+
+RUN apt-get -y update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq xz-utils curl automake make libtool libglib2.0-dev libmagickwand-dev \
+  && curl -sSL "https://github.com/${GHPROJ}/releases/download/${CHAFA_VERSION}/chafa-${CHAFA_VERSION}.tar.xz" > /tmp/chafa-${CHAFA_VERSION}.tar.xz \
+  && xzcat /tmp/chafa-${CHAFA_VERSION}.tar.xz | tar -C /tmp -xvf - \
+  && cd /tmp/chafa-${CHAFA_VERSION} \
+  && mkdir /tmp/usr && mkdir build && cd build && ../autogen.sh --prefix=/usr/local --disable-dependency-tracking && make -j4 && make install
+#  && rm -rf /tmp/chafa-${CHAFA_VERSION}*
+
+FROM ubuntu:20.04
+
+ARG CHAFA_VERSION
+
+RUN apt-get -y update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq libglib2.0 libmagickwand-6.q16
+
+COPY --from=build /usr/local /usr/local
+ENV LD_LIBRARY_PATH=/usr/local/lib
+RUN ldconfig
+
+ENTRYPOINT [ "chafa" ]
+CMD [ "--help" ]

--- a/chafa/Dockerfile
+++ b/chafa/Dockerfile
@@ -1,6 +1,7 @@
+ARG UBUNTU_VERSION=20.04
 ARG CHAFA_VERSION=1.8.0
 
-FROM ubuntu:20.04 AS build
+FROM ubuntu:${UBUNTU_VERSION} AS build
 
 ARG GHPROJ=hpjansson/chafa
 ARG CHAFA_VERSION
@@ -13,7 +14,7 @@ RUN apt-get -y update \
   && mkdir /tmp/usr && mkdir build && cd build && ../autogen.sh --prefix=/usr/local --disable-dependency-tracking && make -j4 && make install
 #  && rm -rf /tmp/chafa-${CHAFA_VERSION}*
 
-FROM ubuntu:20.04
+FROM ubuntu:${UBUNTU_VERSION}
 
 ARG CHAFA_VERSION
 

--- a/chafa/README.md
+++ b/chafa/README.md
@@ -1,0 +1,28 @@
+# chafa
+
+This [project] automatically builds ubuntu-based Docker [images] for [chafa].
+Images are tagged after the name of the [chafa] release at github, e.g. `1.8.0`,
+and new releases are automatically detected. The [images] are created using a
+GitHub [workflow](../.github/workflows/chafa.yml) that automatically relays
+Docker Hub-compatible [hooks](./hooks/).
+
+  [project]: https://github.com/efrecon/docker-images/tree/master/chafa
+  [images]: https://hub.docker.com/r/efrecon/chafa
+  [chafa]: https://github.com/hpjansson/chafa
+
+## Usage
+
+To use these Docker images, you will have to bind-mount your current directory
+and probably respect user and group permissions. For example, the following
+command would perform let you display any image present in your current
+directory or below, if you replaced the `--help` with the relative path to an
+image.
+
+```console
+docker run \
+  -it --rm \
+  -v $(pwd):$(pwd) \
+  -u $(id -u):$(id -g) \
+  -w $(pwd) \
+  efrecon/chafa:1.8.0 --help
+```

--- a/chafa/hooks/build
+++ b/chafa/hooks/build
@@ -1,0 +1,43 @@
+#!/usr/bin/env sh
+
+# Set good defaults to allow script to be run by hand. The two variables below
+# will never be used when run from within the Docker hub.
+DOCKER_REPO=${DOCKER_REPO:-"efrecon/chafa"}
+SOURCE_COMMIT=${SOURCE_COMMIT:-$(git log --no-decorate|grep '^commit'|head -n 1| awk '{print $2}')}
+
+# Minimum version of bat to build for.
+MINVER=${MINVER:-1.0.0}
+
+# You shouldn't really need to have to modify the following variables.
+GH_PROJECT=hpjansson/chafa
+
+# shellcheck disable=SC1091
+. "$(dirname "$0")/reg-tags/image_tags.sh"
+
+# Login at the Docker hub to be able to access info about the image.
+token=$(img_auth "$DOCKER_REPO")
+
+echo "============== Gettings latest releases for $GH_PROJECT at github"
+for tag in $(github_releases "$GH_PROJECT"); do
+  if [ "$(img_version "${tag#v}")" -ge "$(img_version "$MINVER")" ]; then
+    # Get the revision out of the org.opencontainers.image.revision label, this
+    # will be the label where we store information about this repo (it cannot be
+    # the tag, since we tag as the base image).
+    revision=$(img_labels --verbose --token "$token" -- "$DOCKER_REPO" "$tag" |
+                grep "^org.opencontainers.image.revision" |
+                sed -E 's/^org.opencontainers.image.revision=(.+)/\1/')
+    # If the revision is different from the source commit (including empty,
+    # which will happen when our version of the image does not already exist),
+    # build the image, making sure we label with the git commit sha at the
+    # org.opencontainers.image.revision OCI label, but using the same tag as the
+    # library image.
+    if [ "$revision" != "$SOURCE_COMMIT" ]; then
+      echo "============== No ${DOCKER_REPO}:$tag at $SOURCE_COMMIT"
+      docker build \
+        --build-arg CHAFA_VERSION="$tag" \
+        --tag "${DOCKER_REPO}:$tag" \
+        --label "org.opencontainers.image.revision=$SOURCE_COMMIT" \
+        .
+    fi
+  fi
+done

--- a/chafa/hooks/push
+++ b/chafa/hooks/push
@@ -1,0 +1,26 @@
+#!/usr/bin/env sh
+
+# Set good defaults to allow script to be run by hand. The two variables below
+# will never be used when run from within the Docker hub.
+DOCKER_REPO=${DOCKER_REPO:-"efrecon/chafa"}
+SOURCE_COMMIT=${SOURCE_COMMIT:-$(git log --no-decorate|grep '^commit'|head -n 1| awk '{print $2}')}
+
+# Minimum version of bat to build for.
+MINVER=${MINVER:-1.0.0}
+
+# You shouldn't really need to have to modify the following variables.
+GH_PROJECT=hpjansson/chafa
+
+# shellcheck disable=SC1091
+. "$(dirname "$0")/reg-tags/image_tags.sh"
+
+for tag in $(github_releases "$GH_PROJECT"|sort); do
+  if [ "$(img_version "${tag#v}")" -ge "$(img_version "$MINVER")" ]; then
+    if docker image inspect "${DOCKER_REPO}:$tag" >/dev/null 2>&1; then
+      echo "============== Pushing ${DOCKER_REPO}:$tag"
+      docker push "${DOCKER_REPO}:$tag"
+    else
+      echo "!!!!!!!!!!!!!! ${DOCKER_REPO}:$tag was not built, cannot push!"
+    fi
+  fi
+done


### PR DESCRIPTION
This adds a ubuntu-based `chafa` image to easily display images in the terminal. The image is compiled from the released source code automatically.